### PR TITLE
Add the Unidata Python Gallery link to the MetPy README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ Important Links
 
 - Source code repository: https://github.com/Unidata/MetPy
 - HTML Documentation : http://unidata.github.io/MetPy
+- Unidata Python Gallery: https://unidata.github.io/python-gallery/
 - Issue tracker: http://github.com/Unidata/MetPy/issues
 - Gitter chat room: https://gitter.im/Unidata/MetPy
 - Say Thanks: https://saythanks.io/to/unidata

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,8 +99,10 @@ Related Projects
 
 * netCDF4-python_ is the officially blessed Python API for netCDF_
 * siphon_ is an API for accessing remote data on `THREDDS Data Server`__
+* unidata_python_gallery_ is a collection of meteorological Python scripts 
 
 .. _netCDF4-python: https://unidata.github.io/netcdf4-python/
 .. _netCDF: https://www.unidata.ucar.edu/software/netcdf/
 .. _siphon: https://unidata.github.io/siphon/
+.. _unidata_python_gallery: https://unidata.github.io/python-gallery/
 __ https://www.unidata.ucar.edu/software/thredds/current/tds/


### PR DESCRIPTION
This change adds the link https://unidata.github.io/python-gallery/ to the MetPy README

Resolves: #581